### PR TITLE
Implement uplink confirmation

### DIFF
--- a/src/application.c
+++ b/src/application.c
@@ -12,7 +12,8 @@ typedef struct __attribute__((packed)) message {
     int16_t temperature;
     uint8_t min_voltage;
     int16_t rssi;
-    int16_t snr;
+    int8_t snr;
+    uint8_t flags;
 } message_t;
 
 
@@ -43,6 +44,19 @@ static message_t build_status_message()
     msg.min_voltage = isnan(voltage_min) ? UINT8_MAX : (uint8_t)round(voltage_min * 10.0);
     msg.rssi = lora.rssi;
     msg.snr = lora.snr;
+
+    // Flag set logic.
+    
+    //msg.flags = 0; // Reset (DEBUG LINE) 
+    
+    if (last_uplink_confirmed) {
+        msg.flags |= FLAG_UPLINK_CONFIRMED;
+    }
+    if (lora.ack_received) {
+        msg.flags |= FLAG_ACK_RECEIVED;
+    }
+
+
     return msg;
 }
 

--- a/src/application.c
+++ b/src/application.c
@@ -45,17 +45,11 @@ static message_t build_status_message()
     msg.rssi = lora.rssi;
     msg.snr = lora.snr;
 
-    // Flag set logic.
-    
-    //msg.flags = 0; // Reset (DEBUG LINE) 
-    
-    if (last_uplink_confirmed) {
-        msg.flags |= FLAG_UPLINK_CONFIRMED;
-    }
-    if (lora.ack_received) {
-        msg.flags |= FLAG_ACK_RECEIVED;
-    }
-
+    // Flag set logic.    
+    if (last_uplink_confirmed) msg.flags |= FLAG_UPLINK_CONFIRMED;
+    else msg.flags &= ~FLAG_UPLINK_CONFIRMED;
+    if (lora.ack_received) msg.flags |= FLAG_ACK_RECEIVED;
+    else msg.flags &= ~FLAG_ACK_RECEIVED;
 
     return msg;
 }
@@ -152,12 +146,12 @@ void application_task(void)
         if (measurements_left > 0) break;
         if (send) {
             message_t msg = build_status_message();
+            last_uplink_confirmed = false;
             lora_send(&msg, sizeof(msg), true);
             state = STATE_TRANSMITTING;
             led_set(true);
         } else {
-            twr_atci_printfln("status: temperature=%.1f C, min_voltage=%.1f V",
-                temp_get(), voltage_min);
+            twr_atci_printfln("status: temperature=%.1f C, min_voltage=%.1f V", temp_get(), voltage_min);
             state = STATE_IDLE;
         }
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -4,4 +4,8 @@
 #define MEASURE_INTERVAL (15 * SECOND)
 #define SEND_INTERVAL    (1 * MINUTE)
 
+#define FLAG_UPLINK_CONFIRMED   0x01  // 00000001 in binary for message_t.flags
+#define FLAG_ACK_RECEIVED       0x02  // 00000010 
+
+
 extern int measurements_left;

--- a/src/lora.c
+++ b/src/lora.c
@@ -6,6 +6,7 @@ static twr_cmwx1zzabz_t modem;
 
 lora_state_t lora;
 
+static bool last_uplink_confirmed = false; 
 
 static void lora_callback(twr_cmwx1zzabz_t* self, twr_cmwx1zzabz_event_t event, void* param)
 {
@@ -21,9 +22,11 @@ static void lora_callback(twr_cmwx1zzabz_t* self, twr_cmwx1zzabz_event_t event, 
         case TWR_CMWX1ZZABZ_EVENT_SEND_MESSAGE_START:
             twr_log_debug("lora: Sending message");
             voltage_measure(20, false);
+            
             break;
 
         case TWR_CMWX1ZZABZ_EVENT_SEND_MESSAGE_DONE:
+            last_uplink_confirmed = false;  // If the message is sent, consider it as not confirmed unless explicitly confirmed
             twr_log_debug("lora: Message sent");
             break;
 
@@ -54,12 +57,18 @@ static void lora_callback(twr_cmwx1zzabz_t* self, twr_cmwx1zzabz_event_t event, 
             break;
 
         case TWR_CMWX1ZZABZ_EVENT_MESSAGE_CONFIRMED:
+			lora.ack_received = true;
+            last_uplink_confirmed = true;
             twr_log_debug("lora: Message confirmed");
             twr_cmwx1zzabz_rfq(&modem);
             twr_scheduler_plan_now(0);
             break;
 
         case TWR_CMWX1ZZABZ_EVENT_MESSAGE_NOT_CONFIRMED:
+			lora.ack_received = false;
+            last_uplink_confirmed = false;
+			lora.rssi = 0;
+            lora.snr = 0;
             twr_log_warning("lora: Message NOT confirmed");
             twr_scheduler_plan_now(0);
             break;

--- a/src/lora.c
+++ b/src/lora.c
@@ -6,7 +6,7 @@ static twr_cmwx1zzabz_t modem;
 
 lora_state_t lora;
 
-static bool last_uplink_confirmed = false; 
+static bool last_uplink_confirmed; 
 
 static void lora_callback(twr_cmwx1zzabz_t* self, twr_cmwx1zzabz_event_t event, void* param)
 {
@@ -20,13 +20,14 @@ static void lora_callback(twr_cmwx1zzabz_t* self, twr_cmwx1zzabz_event_t event, 
             break;
 
         case TWR_CMWX1ZZABZ_EVENT_SEND_MESSAGE_START:
+            //last_uplink_confirmed = false;
             twr_log_debug("lora: Sending message");
             voltage_measure(20, false);
             
             break;
 
         case TWR_CMWX1ZZABZ_EVENT_SEND_MESSAGE_DONE:
-            last_uplink_confirmed = false;  // If the message is sent, consider it as not confirmed unless explicitly confirmed
+            //last_uplink_confirmed = true;
             twr_log_debug("lora: Message sent");
             break;
 
@@ -58,7 +59,6 @@ static void lora_callback(twr_cmwx1zzabz_t* self, twr_cmwx1zzabz_event_t event, 
 
         case TWR_CMWX1ZZABZ_EVENT_MESSAGE_CONFIRMED:
 			lora.ack_received = true;
-            last_uplink_confirmed = true;
             twr_log_debug("lora: Message confirmed");
             twr_cmwx1zzabz_rfq(&modem);
             twr_scheduler_plan_now(0);
@@ -66,7 +66,6 @@ static void lora_callback(twr_cmwx1zzabz_t* self, twr_cmwx1zzabz_event_t event, 
 
         case TWR_CMWX1ZZABZ_EVENT_MESSAGE_NOT_CONFIRMED:
 			lora.ack_received = false;
-            last_uplink_confirmed = false;
 			lora.rssi = 0;
             lora.snr = 0;
             twr_log_warning("lora: Message NOT confirmed");
@@ -120,6 +119,7 @@ void lora_send(const void* msg, size_t len, bool confirmed)
 {
     if (confirmed) twr_cmwx1zzabz_send_message_confirmed(&modem, msg, len);
     else twr_cmwx1zzabz_send_message(&modem, msg, len);
+    last_uplink_confirmed = confirmed;
 }
 
 

--- a/src/lora.h
+++ b/src/lora.h
@@ -10,6 +10,7 @@ typedef struct {
     uint8_t gwcount;
     uint32_t uplink;
     uint32_t downlink;
+	bool ack_received; 
 } lora_state_t;
 
 extern lora_state_t lora;
@@ -17,3 +18,6 @@ extern lora_state_t lora;
 extern void lora_init(bool debug);
 extern void lora_send(const void* msg, size_t len, bool confirmed);
 extern bool lora_ready();
+
+
+extern bool last_uplink_confirmed;


### PR DESCRIPTION
I have added a flag for uplink confirmation in lora.h and lora.c, and am setting this flag based on the callback events TWR_CMWX1ZZABZ_EVENT_MESSAGE_CONFIRMED and TWR_CMWX1ZZABZ_EVENT_MESSAGE_NOT_CONFIRMED. I've made sure that the last_uplink_confirmed flag is being updated based on whether the last message was confirmed or not - so i reset the flag when a new message is sent. I have intentionally not reset msg.flags in application.c to ensure that the flags persist across messages. But this may be wrong as it looks like we are instantiating a new message_t each time? I'm not sure if after every send the device power-cycles - but the fact that msg is set as a static variable within the scope of build_status_message() whould mean that msg should retain its value across different invocations of the function.